### PR TITLE
Remove deprecated Distutils

### DIFF
--- a/trunk/grokevt-distutils.py
+++ b/trunk/grokevt-distutils.py
@@ -1,4 +1,4 @@
 # Called from make with appropriate python version
 
-from distutils.core import setup
+from setuptools import setup
 setup(name='grokevt', version='0.5', package_dir={'':'lib'}, py_modules=['grokevt'])


### PR DESCRIPTION
This commit remove distutils.core.setup from source to use setuptools.setup instead. Distutils is deprecated and remove from Python3.12.

Original bug reported here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1065871